### PR TITLE
 in app messaging working

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Jammin">
-        <activity android:name=".activities.ChatPage"></activity>
+        <activity android:name=".activities.MessagingActivity"></activity>
+        <activity android:name=".activities.ChatPage" />
         <activity android:name=".activities.SignUpPage" />
         <activity
             android:name=".activities.MyFavoritesPage"

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/ChatPage.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/ChatPage.java
@@ -3,13 +3,21 @@ package com.andyagulue.github.jammin.activities;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.content.Intent;
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.os.Handler;
 import android.telephony.ClosedSubscriberGroupInfo;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import com.amplifyframework.api.graphql.model.ModelQuery;
 import com.amplifyframework.auth.AuthUser;
@@ -22,6 +30,7 @@ import com.amplifyframework.datastore.generated.model.Musician;
 import com.andyagulue.github.jammin.R;
 import com.andyagulue.github.jammin.adapters.ChatAdapter;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
@@ -34,10 +43,12 @@ public class ChatPage extends AppCompatActivity {
     private ChatAdapter chatAdapter;
     private final ArrayList<Message> messageArrayList = new ArrayList<>();
     String username;
+    String userName;
     AuthUser authUser = Amplify.Auth.getCurrentUser();
     Handler chatPageHandler;
     Musician[] musicianList;
     Musician currentMusician;
+
 
 
     @Override
@@ -49,10 +60,18 @@ public class ChatPage extends AppCompatActivity {
         getCurrentUser();
 
 
+
+
         Log.i(TAG, "onCreate: authUser username: " + authUser.getUsername());
 //        Log.i(TAG, "onCreate: currentUser Musician: " + currentMusician.getUsername());
 
         username = getIntent().getStringExtra("username");
+        userName = authUser.getUsername();
+
+
+        downloadImageFromS3(username);
+        TextView profileName = findViewById(R.id.chatUsername);
+        profileName.setText(getIntent().getStringExtra("fullName"));
 
         ListView listView = findViewById(R.id.messageListView);
         chatAdapter = new ChatAdapter(getApplicationContext(), R.id.messageListView, messageArrayList);
@@ -83,10 +102,15 @@ public class ChatPage extends AppCompatActivity {
 
     private void onNewMessageReceived(DataStoreItemChange<Message> messageChanged) {
         if (messageChanged.type().equals(DataStoreItemChange.Type.CREATE)) {
+            Log.i(TAG, "onNewMessageReceived: " + messageChanged);
             Message message = messageChanged.item();
-            Log.i(TAG, "onNewMessageReceived: " + message);
-            messageArrayList.add(message);
-            runOnUiThread(()-> chatAdapter.notifyDataSetChanged());
+            if(message.getRecipient().equals(authUser.getUsername()) ||
+                    message.getMusician().getUsername().equals(authUser.getUsername())){
+                Log.i(TAG, "onNewMessageReceived: " + message);
+                messageArrayList.add(message);
+            }
+//            runOnUiThread(()-> chatAdapter.notifyDataSetChanged());
+            chatPageHandler.sendEmptyMessage(141);
         }
     }
 
@@ -97,8 +121,20 @@ public class ChatPage extends AppCompatActivity {
                 Where.sorted(Message.DATE.ascending()),
                 result -> {
                     while (result.hasNext()) {
-                        Message message = result.next();
-                        messageArrayList.add(message);
+                        Log.i(TAG, "getPreviousMessages: result: " + result);
+//                        Log.i(TAG, "getPreviousMessages: result" + result.next());
+//                        Log.i(TAG, "getPreviousMessages: getRecipient : " + result.next().getRecipient());
+//                        Log.i(TAG, "getPreviousMessages: getMusician: " + result.next().getMusician().getUsername());
+//                        Log.i(TAG, "getPreviousMessages: currentUser: " + authUser.getUsername());
+//                        Log.i(TAG, "getPreviousMessages: expected Recipient: " + username);
+
+                            Message message = result.next();
+                            if(message.getRecipient().equals(username) &&
+                                    message.getMusician().getUsername().equals(authUser.getUsername()) ||
+                                        message.getRecipient().equals(authUser.getUsername()) &&
+                                                message.getMusician().getUsername().equals(username)){
+                                messageArrayList.add(message);
+                            }
                         chatPageHandler.sendEmptyMessage(141);
                     }
                 },
@@ -142,6 +178,7 @@ public class ChatPage extends AppCompatActivity {
                     }
             );
         }
+        messageContentTxt.setText("");
 
     }
     public void getCurrentUser(){
@@ -159,6 +196,53 @@ public class ChatPage extends AppCompatActivity {
         );
         Log.i(TAG, "getCurrentUser2: " + musicianList[0]);
 
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.menu, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        switch (item.getItemId()){
+            case R.id.item1:
+                Toast.makeText(this, "clicked profile", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent(getApplicationContext(), PublicMusicianProfilePage.class );
+                intent.putExtra("username", userName);
+                startActivity(intent);
+                return true;
+            case R.id.item2:
+                Toast.makeText(this, "clicked home", Toast.LENGTH_SHORT).show();
+                Intent intent2 = new Intent(getApplicationContext(), DiscoverPage.class );
+                startActivity(intent2);
+                return true;
+            case R.id.item3:
+                Toast.makeText(this, "clicked favorites", Toast.LENGTH_SHORT).show();
+                Intent intent3 = new Intent(getApplicationContext(), MyFavoritesPage.class );
+                startActivity(intent3);
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+
+    }
+
+    void downloadImageFromS3(String key) {
+        ImageView profilePic = findViewById(R.id.chatProfilePic);
+        Amplify.Storage.downloadFile(
+                key,
+                new File(getApplicationContext().getFilesDir(), key),
+                r -> {
+                    profilePic.setImageBitmap(BitmapFactory.decodeFile(r.getFile().getPath()));
+                },
+                e -> {
+                    profilePic.setImageResource(R.drawable.ic_baseline_account_circle_24);
+                }
+        );
     }
 
 }

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/ChatPage.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/ChatPage.java
@@ -13,7 +13,9 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -48,6 +50,7 @@ public class ChatPage extends AppCompatActivity {
     Handler chatPageHandler;
     Musician[] musicianList;
     Musician currentMusician;
+    ImageButton chatBackButton;
 
 
 
@@ -58,6 +61,12 @@ public class ChatPage extends AppCompatActivity {
 
         musicianList = new Musician[1];
         getCurrentUser();
+
+        chatBackButton = findViewById(R.id.chatBackButton);
+        chatBackButton.setOnClickListener(v -> {
+            Intent intent = new Intent(ChatPage.this, MessagingActivity.class);
+            startActivity(intent);
+        });
 
 
 
@@ -86,6 +95,8 @@ public class ChatPage extends AppCompatActivity {
                 failure -> Log.i(TAG, "Observation failed"),
                 () -> Log.i(TAG, "Observation completed:")
         );
+
+
 
         chatPageHandler = new Handler(this.getMainLooper()){
             @Override

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/CreateProfilePage.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/CreateProfilePage.java
@@ -209,67 +209,80 @@ public class CreateProfilePage extends AppCompatActivity {
                     .bio(bio)
                     .username(userName)
 //                    .band(defaultBand) //TODO: Musician may not be a part of a band.
+                    .id(authUser.getUserId())
                     .build();
 
             Log.i(TAG, "onCreate: Made it to 220");
-            Amplify.API.query(
-                    ModelQuery.list(Musician.class, Musician.USERNAME.eq(userName)),
-                    response-> {
-                        if(!response.getData().getItems().iterator().hasNext()){
-                            Amplify.API.mutate(
-                                    ModelMutation.create(newMusician),
-                                    r ->{
-                                        Log.i(TAG, "onCreate: Created a new musician" );
-                                        Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
-                                        startActivity(intent);
-                                    },
-                                    err ->{
-                                        Log.e(TAG, "onCreate: Unable to create musician -->",err );
-                                    }
-                            );
-                            return;
-                        }
-                        Musician existingMusician = response.getData().getItems().iterator().next();
-                        Log.i(TAG, "musician" + existingMusician);
-                        Musician updatedMusician = Musician.builder()
-                                .firstName(firstName)
-                                .lastName(lastName)
-                                .vocalist(isVocalist)
-                                .instruments(instruments)
-                                .genres(genres)
-                                .bio(bio)
-                                .username(existingMusician.getUsername())
-                                .id(existingMusician.getId())
-                                .build();
+//            Amplify.API.query(
+//                    ModelQuery.list(Musician.class, Musician.USERNAME.eq(userName)),
+//                    response-> {
+//                        if(!response.getData().getItems().iterator().hasNext()){
+//                            Amplify.API.mutate(
+//                                    ModelMutation.create(newMusician),
+//                                    r ->{
+//                                        Log.i(TAG, "onCreate: Created a new musician" );
+//                                        Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
+//                                        startActivity(intent);
+//                                    },
+//                                    err ->{
+//                                        Log.e(TAG, "onCreate: Unable to create musician -->",err );
+//                                    }
+//                            );
+//                            return;
+//                        }
+//                        Musician existingMusician = response.getData().getItems().iterator().next();
+//                        Log.i(TAG, "musician" + existingMusician);
+//                        Musician updatedMusician = Musician.builder()
+//                                .firstName(firstName)
+//                                .lastName(lastName)
+//                                .vocalist(isVocalist)
+//                                .instruments(instruments)
+//                                .genres(genres)
+//                                .bio(bio)
+//                                .username(existingMusician.getUsername())
+//                                .id(existingMusician.getId())
+//                                .build();
+//
+//                       Log.i(TAG, "onCreate: updated musician: " + updatedMusician.firstName);
+//
+//                        Amplify.API.mutate(
+//                                ModelMutation.create(updatedMusician),
+//                                res-> {
+//                                    Log.i(TAG, "updated musician" + res);
+//                                    Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
+//                                    startActivity(intent);
+//                                },
+//                                err -> {
+//                                    Log.i(TAG, "did not update musician" + err);
+//                                }
+//                        );
+//                    },
+//
+//                    error ->{
+//                        Log.i(TAG, "musician is not in the database");
+//                        Amplify.API.mutate(
+//                                ModelMutation.create(newMusician),
+//                                response ->{
+//                                    Log.i(TAG, "onCreate: Created a new musician" );
+//                                    Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
+//                                    startActivity(intent);
+//                                },
+//                                err ->{
+//                                    Log.e(TAG, "onCreate: Unable to create musician -->",error );
+//                                }
+//                        );
+//                    }
+//            );
 
-                       Log.i(TAG, "onCreate: updated musician: " + updatedMusician.firstName);
-
-                        Amplify.API.mutate(
-                                ModelMutation.create(updatedMusician),
-                                res-> {
-                                    Log.i(TAG, "updated musician" + res);
-                                    Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
-                                    startActivity(intent);
-                                },
-                                err -> {
-                                    Log.i(TAG, "did not update musician" + err);
-                                }
-                        );
+            Amplify.DataStore.save(
+                    newMusician,
+                    r -> {
+                        Log.i(TAG, "onCreate: Created new Musician" + r.item());
+                        Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
+                        startActivity(intent);
                     },
-
-                    error ->{
-                        Log.i(TAG, "musician is not in the database");
-                        Amplify.API.mutate(
-                                ModelMutation.create(newMusician),
-                                response ->{
-                                    Log.i(TAG, "onCreate: Created a new musician" );
-                                    Intent intent = new Intent(CreateProfilePage.this, DiscoverPage.class);
-                                    startActivity(intent);
-                                },
-                                err ->{
-                                    Log.e(TAG, "onCreate: Unable to create musician -->",error );
-                                }
-                        );
+                    e -> {
+                        Log.i(TAG, "onCreate: did not create new Musician" + e.getMessage());
                     }
             );
             uploadImage();

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/MainActivity.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/MainActivity.java
@@ -108,6 +108,14 @@ public class MainActivity extends AppCompatActivity {
 
         AuthUser authUser = Amplify.Auth.getCurrentUser();
 
+//        Amplify.DataStore.clear(
+//                () -> Amplify.DataStore.start(
+//                        () -> Log.i("MyAmplifyApp", "DataStore started"),
+//                        error -> Log.e("MyAmplifyApp", "Error starting DataStore: ", error)
+//                ),
+//                error -> Log.e("MyAmplifyApp", "Error clearing DataStore: ", error)
+//        );
+
 
 
         if (authUser != null){
@@ -125,13 +133,7 @@ public class MainActivity extends AppCompatActivity {
 //        );
 
 
-//        Amplify.DataStore.clear(
-//                () -> Amplify.DataStore.start(
-//                        () -> Log.i("MyAmplifyApp", "DataStore started"),
-//                        error -> Log.e("MyAmplifyApp", "Error starting DataStore: ", error)
-//                ),
-//                error -> Log.e("MyAmplifyApp", "Error clearing DataStore: ", error)
-//        );
+
 
 
 

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/MessagingActivity.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/MessagingActivity.java
@@ -1,0 +1,132 @@
+package com.andyagulue.github.jammin.activities;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.amplifyframework.auth.AuthUser;
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.core.model.temporal.Temporal;
+import com.amplifyframework.datastore.generated.model.Message;
+import com.amplifyframework.datastore.generated.model.Musician;
+import com.andyagulue.github.jammin.R;
+import com.andyagulue.github.jammin.adapters.MessagingAdapter;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+public class MessagingActivity extends AppCompatActivity {
+    String TAG = "MessagingActivity";
+
+    String userName;
+    ArrayList<Message> messageArrayList;
+    Handler messagingActivityHandler;
+    String authUser = Amplify.Auth.getCurrentUser().getUsername();
+
+
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_messaging);
+
+
+
+        createMessagesList();
+        buildRecyclerView();
+        Log.i(TAG, "onCreate: Page was created");
+        Log.i(TAG, "onCreate: MessageArrayListSize " + messageArrayList.size());
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    private void createMessagesList() {
+        messageArrayList = new ArrayList<>();
+        HashMap<String, String> messageHashMap = new HashMap<>();
+        Amplify.DataStore.query(
+                Message.class,
+                Where.sorted(Message.DATE.descending()),
+                result -> {
+                    while (result.hasNext()) {
+                        Log.i(TAG, "getPreviousMessages: result: " + result);
+
+                        Message message = result.next();
+                        if(message.getRecipient().equals(authUser)){
+                            int size = messageHashMap.size();
+                            messageHashMap.putIfAbsent(message.getMusician().getUsername(), message.getContent());
+                            if(messageHashMap.size() > size){
+                                messageArrayList.add(message);
+                            }
+                        }
+                        if(message.getMusician().getUsername().equals(authUser)){
+                            int size = messageHashMap.size();
+                            messageHashMap.putIfAbsent(message.getRecipient(),message.getContent());
+                            if(messageHashMap.size() > size){
+                                messageArrayList.add(message);
+                            }
+                        }
+                    }
+                    messagingActivityHandler.sendEmptyMessage(151);
+                },
+                Throwable::printStackTrace
+        );
+    }
+
+    private void buildRecyclerView() {
+        Log.i(TAG, "buildRecyclerView: ");
+        RecyclerView messagesRecyclerView = findViewById(R.id.messagingRecyclerView);
+        messagesRecyclerView.setHasFixedSize(true);
+        RecyclerView.LayoutManager rvLayoutManager = new LinearLayoutManager(this);
+        MessagingAdapter rvAdapter = new MessagingAdapter(messageArrayList);
+        messagesRecyclerView.setLayoutManager(rvLayoutManager);
+        messagesRecyclerView.setAdapter(rvAdapter);
+
+        rvAdapter.setOnMessagePreviewClickListener(new MessagingAdapter.onMessagePreviewClickListener() {
+            @Override
+            public void onMessageClick(int position) {
+                Intent intent = new Intent(MessagingActivity.this, ChatPage.class);
+                if(messageArrayList.get(position).getRecipient().equals(authUser)){
+                    intent.putExtra("username", messageArrayList.get(position).getMusician().getUsername());
+                }else{
+                    intent.putExtra("username", messageArrayList.get(position).getRecipient());
+                }
+                Log.i(TAG, "onMessageClick: musician" + messageArrayList.get(position).getMusician());
+                Log.i(TAG, "onMessageClick: recipient" + messageArrayList.get(position).getRecipient());
+                startActivity(intent);
+            }
+
+        });
+        messagingActivityHandler = new Handler(this.getMainLooper()){
+            @Override
+            public void handleMessage(@NonNull android.os.Message msg) {
+                super.handleMessage(msg);
+                if(msg.what == 151){
+                    Objects.requireNonNull(messagesRecyclerView.getAdapter()).notifyDataSetChanged();
+                    Log.i(TAG, "onCreate: messageArrayListSize" + messageArrayList.size());
+//                    Log.i(TAG, "handleMessage: " + messageArrayList.get(0).getMusician());
+
+                }
+            }
+        };
+
+    }
+
+
+
+
+}

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/MyFavoritesPage.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/MyFavoritesPage.java
@@ -138,6 +138,8 @@ public class MyFavoritesPage extends AppCompatActivity {
                 Log.i(TAG, "onMusicianClick: " + favoriteMusicians.get(position).getUsername());
                 Intent intent = new Intent(MyFavoritesPage.this, ChatPage.class);
                 intent.putExtra("username", favoriteMusicians.get(position).getUsername());
+                intent.putExtra("fullName", favoriteMusicians.get(position).getFirstName()
+                        + " " + favoriteMusicians.get(position).getLastName());
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/com/andyagulue/github/jammin/activities/MyFavoritesPage.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/activities/MyFavoritesPage.java
@@ -100,6 +100,7 @@ public class MyFavoritesPage extends AppCompatActivity {
     }
 
     public void buildRecyclerView(){
+        Log.i(TAG, "buildRecyclerView: ");
         RecyclerView favRecyclerView = findViewById(R.id.favoriteMusicianRecyclerView);
         favRecyclerView.setHasFixedSize(true);
         RecyclerView.LayoutManager rvLayoutManager = new LinearLayoutManager(this);

--- a/app/src/main/java/com/andyagulue/github/jammin/adapters/ChatAdapter.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/adapters/ChatAdapter.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 
 import com.amplifyframework.core.Amplify;
 import com.amplifyframework.datastore.generated.model.Message;
+import com.amplifyframework.datastore.generated.model.Musician;
 import com.andyagulue.github.jammin.R;
 
 import org.jetbrains.annotations.NotNull;
@@ -30,15 +31,13 @@ public class ChatAdapter extends ArrayAdapter<Message> {
         Message message = getItem(position);
         boolean isCurrentUserMessage;
         Log.i("chatAdapter**", "getView: " + message);
-        String userName = Amplify.Auth.getCurrentUser().getUsername();
-        Log.i("chatAdapter**", "getView: " + userName);
+        String userId = Amplify.Auth.getCurrentUser().getUserId();
+        Log.i("chatAdapter**", "getView: " + userId);
         Log.i("chatAdapter**", "getView: " + message.getMusician());
 
-        if(message.getMusician() != null){
-            isCurrentUserMessage = message.getMusician().getUsername().equals(userName);
-        }else{
-            isCurrentUserMessage = false;
-        }
+        isCurrentUserMessage = message.getMusician().getId().equals(userId);
+
+
         LayoutInflater layoutInflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         View view;
         if(isCurrentUserMessage){

--- a/app/src/main/java/com/andyagulue/github/jammin/adapters/MessagingAdapter.java
+++ b/app/src/main/java/com/andyagulue/github/jammin/adapters/MessagingAdapter.java
@@ -1,0 +1,135 @@
+package com.andyagulue.github.jammin.adapters;
+
+import android.graphics.BitmapFactory;
+import android.os.Handler;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.amplifyframework.core.Amplify;
+import com.amplifyframework.core.model.query.Where;
+import com.amplifyframework.datastore.generated.model.Message;
+import com.amplifyframework.datastore.generated.model.Musician;
+import com.andyagulue.github.jammin.R;
+import com.andyagulue.github.jammin.activities.MessagingActivity;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import javax.security.auth.login.LoginException;
+
+public class MessagingAdapter extends RecyclerView.Adapter<MessagingAdapter.MessagingViewHolder> {
+    private ArrayList<Message> musicianMessageList;
+    private onMessagePreviewClickListener messageListener;
+
+
+
+    public interface onMessagePreviewClickListener{
+        void onMessageClick(int position);
+    }
+    public void setOnMessagePreviewClickListener(onMessagePreviewClickListener listener){
+        messageListener = listener;
+    }
+
+    public static class MessagingViewHolder extends RecyclerView.ViewHolder{
+
+        public ImageView musicianMessageProfileImage;
+        public TextView musicianMessageFullName;
+        public TextView musicianMessagePreview;
+
+        public MessagingViewHolder(@NonNull @NotNull View itemView, onMessagePreviewClickListener listener) {
+            super(itemView);
+
+            musicianMessageProfileImage = itemView.findViewById(R.id.musicianMessageProfileImage);
+            musicianMessageFullName = itemView.findViewById(R.id.musicianMessageFullName);
+            musicianMessagePreview = itemView.findViewById(R.id.musicianMessagePreview);
+
+
+            itemView.setOnClickListener(v -> {
+                if(listener != null){
+                    int position = getAdapterPosition();
+                    if(position != RecyclerView.NO_POSITION){
+                        listener.onMessageClick(position);
+                    }
+                }
+            });
+        }
+    }
+
+    public MessagingAdapter(ArrayList<Message> messagesList) {
+        musicianMessageList = messagesList;
+    }
+
+    @NonNull
+    @NotNull
+    @Override
+    public MessagingViewHolder onCreateViewHolder(@NonNull @NotNull ViewGroup parent, int viewType) {
+        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.musician_message_cardview, parent, false);
+        MessagingViewHolder mvh = new MessagingViewHolder(v, messageListener);
+        return mvh;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull @NotNull MessagingAdapter.MessagingViewHolder holder, int position) {
+        Message currentMessage = musicianMessageList.get(position);
+        String userName = Amplify.Auth.getCurrentUser().getUsername();
+
+        if(currentMessage.getMusician().getUsername().equals(userName)){
+            downloadImageFromS3(holder,currentMessage.getRecipient());
+            amplifyQuery(holder, currentMessage.getRecipient());
+        }else{
+            downloadImageFromS3(holder,currentMessage.getMusician().getUsername());
+            String fullName = currentMessage.getMusician().getFirstName() + " " + currentMessage.getMusician().getLastName();
+            holder.musicianMessageFullName.setText(fullName);
+        }
+        holder.musicianMessagePreview.setText(currentMessage.getContent());
+
+    }
+
+    @Override
+    public int getItemCount() {
+        return musicianMessageList.size();
+    }
+
+
+    void downloadImageFromS3(MessagingAdapter.MessagingViewHolder holder, String key){
+        Amplify.Storage.downloadFile(
+                key,
+                new File(holder.itemView.getContext().getFilesDir(), key),
+                r -> {
+                    holder.musicianMessageProfileImage.setImageBitmap(BitmapFactory.decodeFile(r.getFile().getPath()));
+                },
+                e -> {
+                    holder.musicianMessageProfileImage.setImageResource(R.drawable.ic_baseline_account_circle_24);
+                }
+        );
+
+    }
+    void amplifyQuery(MessagingAdapter.MessagingViewHolder holder, String username){
+        Amplify.DataStore.query(
+                Musician.class,
+                response ->{
+                    while(response.hasNext()) {
+                        Musician musician = response.next();
+                        if(musician.getUsername().equals(username)){
+                            String fullName1 = musician.getFirstName() + " " + musician.getLastName();
+                            holder.musicianMessageFullName.setText(fullName1);
+                        }
+
+                    }
+                },
+                error -> {
+
+                });
+    }
+
+}

--- a/app/src/main/res/layout/activity_chat_page.xml
+++ b/app/src/main/res/layout/activity_chat_page.xml
@@ -7,6 +7,55 @@
     android:padding="10dp"
     tools:context=".activities.ChatPage">
 
+    <androidx.cardview.widget.CardView
+        android:id="@+id/chatHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" >
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageButton
+                android:id="@+id/chatBackButton"
+                android:layout_width="39dp"
+                android:layout_height="32dp"
+                android:layout_marginStart="16dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="?attr/homeAsUpIndicator" />
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/cardView"
+                android:layout_width="49dp"
+                android:layout_height="43dp"
+                app:cardCornerRadius="100dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/chatProfilePic"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    app:srcCompat="@drawable/ic_baseline_account_circle_24" />
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                android:id="@+id/chatUsername"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="TextView"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/cardView" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.cardview.widget.CardView>
+
     <EditText
         android:id="@+id/messageContentEditText"
         android:layout_width="338dp"
@@ -27,9 +76,9 @@
         android:layout_width="401dp"
         android:layout_height="653dp"
         android:layout_above="@+id/sendMessageButton"
-        android:layout_alignParentTop="true"
+        android:layout_below="@+id/chatHeader"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="0dp"
+        android:layout_marginTop="10dp"
         android:layout_marginBottom="0dp"
         android:divider="@android:color/transparent"
         android:dividerHeight="0dp"

--- a/app/src/main/res/layout/activity_discover_page.xml
+++ b/app/src/main/res/layout/activity_discover_page.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/DiscoverPageLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/darker_gray"

--- a/app/src/main/res/layout/activity_messaging.xml
+++ b/app/src/main/res/layout/activity_messaging.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.MessagingActivity">
+
+    <TextView
+        android:id="@+id/messagingTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:text="Messaging"
+        android:textAlignment="center"
+        android:textSize="20dp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/messagingRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="670dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/messagingTextView" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/musician_message_cardview.xml
+++ b/app/src/main/res/layout/musician_message_cardview.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="4dp"
+    android:alpha="0.8"
+    app:cardCornerRadius="4dp"
+    app:cardElevation="2dp">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="4dp">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/musicianMessageProfileCardView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp"
+            app:cardCornerRadius="100dp">
+
+            <ImageView
+                android:id="@+id/musicianMessageProfileImage"
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:scaleType="centerCrop"
+                app:srcCompat="@drawable/ic_launcher_foreground" />
+        </androidx.cardview.widget.CardView>
+
+        <RelativeLayout
+            android:layout_width="305dp"
+            android:layout_height="90dp"
+            android:layout_alignParentEnd="true"
+            android:layout_marginStart="0dp"
+            android:layout_marginEnd="0dp"
+            android:layout_toEndOf="@+id/musicianMessageProfileCardView"
+            android:padding="4dp">
+
+            <TextView
+                android:id="@+id/musicianMessageFullName"
+                android:layout_width="128dp"
+                android:layout_height="wrap_content"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:layout_centerHorizontal="false"
+                android:layout_marginStart="0dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="5dp"
+                android:lines="1"
+                android:text="First Last"
+                android:textAlignment="center"
+                android:textColor="#272424"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/musicianMessagePreview"
+                android:layout_width="267dp"
+                android:layout_height="38dp"
+                android:layout_below="@+id/musicianMessageFullName"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentBottom="true"
+                android:layout_marginStart="15dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="4dp"
+                android:maxLines="2"
+                android:text="TextView" />
+
+        </RelativeLayout>
+
+    </RelativeLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -18,4 +18,10 @@
         android:id="@+id/item4"
         android:title="Logout"
         app:showAsAction="never"/>
+
+    <item
+        android:id="@+id/item5"
+        android:title="messaging"
+        android:icon="@drawable/ic_baseline_message_24"
+        app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
- implemented in app messaging allowing users to message back and forth to each other from inside the app
- this is possible by using amplify datastore and dynamoDB to store a list of messages in the "messages" table that has a 1:many relationship with the "Musician" table. 
- the messages have a recipient block and a musician block. The recipient is filled in with the intended recipient by clicking on the "message" icon on the favorites page. That opens up a chat page that will display all the messages to and from the current authenticated user and the recipient user. 
- the chat page also implements a method called onMessageRecieved that listens for any change in the message table in the database and populates that message on the chatpage if its recipient is the current user or the intended recipient. 
- if a message meets all the criteria to be populated on the page, it is then filtered to determine who sent it. if the message was sent by the current authenticated user, it uses the "message_sent" layout which is the green background. If not, it uses the "message_received" layout. 
- in order to get all of this to work I had to erase the entire dynamoDB database and clear the local storage in datastore. but now it works flawlessly. 